### PR TITLE
Add GitHub projects endpoint

### DIFF
--- a/backend/franky/model/project.py
+++ b/backend/franky/model/project.py
@@ -1,0 +1,18 @@
+from typing import List, Optional
+
+
+class ProjectData:
+
+    def __init__(self, name: str, start: str, end: Optional[str], tags: List[str]):
+        """
+        User project data.
+
+        :param name: Project name.
+        :param start: Project start date.
+        :param end: Project end date.
+        :param tags: A list of tags that project is associated with.
+        """
+        self.name = name
+        self.start = start
+        self.end = end
+        self.tags = tags or []

--- a/backend/franky/model/user.py
+++ b/backend/franky/model/user.py
@@ -4,6 +4,13 @@ from typing import Optional, List
 class UserData:
 
     def __init__(self, login: str, name: Optional[str], languages: List[str]):
+        """
+        User metadata.
+
+        :param login: Unique user login. Such as john_johnson.
+        :param name: Non unique user name. Such as John Johnson.
+        :param languages: A list of languages that user is associated with.
+        """
         self.login = login
         self.name = name
-        self.languages = languages
+        self.languages = languages or []

--- a/backend/franky/server.py
+++ b/backend/franky/server.py
@@ -1,23 +1,31 @@
 import os
+from typing import List
+
 from flask import Flask
+
+from model import UserData
+from model.project import ProjectData
 from service import GitHub
-from utils import json_endpoint
+from utils import convert_to_json
 
 app = Flask(__name__)
 
 
 @app.route('/ping', methods=['GET'])
-def ping():
+def ping() -> str:
     return 'From franky with ping!'
 
 
 @app.route('/api/github/<username>', methods=['GET'])
-@json_endpoint
-def github(username):
-    return GitHub().user(username)
+def github_user(username) -> UserData:
+    return convert_to_json(GitHub().user(username))
 
 
-docker_host=os.getenv('DOCKER_NETWORK_HOST') or '0.0.0.0'
+@app.route('/api/github/<username>/projects', methods=['GET'])
+def github_projects(username) -> List[ProjectData]:
+    return convert_to_json(GitHub().projects(username))
+
 
 if __name__ == '__main__':
+    docker_host = os.getenv('DOCKER_NETWORK_HOST', '0.0.0.0')
     app.run(host=docker_host)

--- a/backend/franky/service/github/github.py
+++ b/backend/franky/service/github/github.py
@@ -3,12 +3,13 @@ import operator
 import os
 from datetime import datetime, timedelta
 from functools import reduce
-from typing import Optional
+from typing import Optional, List
 
 import jwt
 import requests
 
 from model import UserData
+from model.project import ProjectData
 from service import Service
 
 
@@ -20,16 +21,27 @@ class GitHub(Service):
 
     def __init__(self, rest_endpoint='https://api.github.com', graphql_endpoint='https://api.github.com/graphql',
                  app_id=None, installation_id=None, private_path=None):
+        """
+        GitHub integrated service.
+
+        :param rest_endpoint: GitHub REST API endpoint.
+        :param graphql_endpoint: GitHub GraphQL API endpoint.
+        :param app_id: Associated GitHub App id.
+        :param installation_id: Associated GitHub App installation id.
+        :param private_path: Associated GitHub App private key path.
+        """
         self._rest_endpoint = rest_endpoint
         self._graphql_endpoint = graphql_endpoint
         self._app_id = app_id or os.environ['GITHUB_APP_ID']
         self._installation_id = installation_id or os.environ['GITHUB_INSTALLATION']
         self._private_path = private_path or os.environ['GITHUB_PRIVATE_PATH']
         self._token = None
+        self._page_size = 10
+        self._date_format = '%Y-%m-%dT%H:%M:%SZ'
+        self._active_projects_period = timedelta(weeks=2)
 
-    def user(self, user_name) -> Optional[UserData]:
+    def user(self, username) -> Optional[UserData]:
         cursor = None
-        page_size = 10
         datas = []
         while True:
             request_payload = {
@@ -39,7 +51,6 @@ class GitHub(Service):
                         name
                         login
                         repositories(after: %(cursor)s, first: %(page_size)s) {
-                          totalCount
                           pageInfo {
                             endCursor
                           }
@@ -54,9 +65,9 @@ class GitHub(Service):
                       }
                     }
                 ''' % {
-                    'user_name': user_name,
+                    'user_name': username,
                     'cursor': ('\"%s\"' % cursor) if cursor else 'null',
-                    'page_size': page_size
+                    'page_size': self._page_size
                 }
             }
             response_data = self._call(request_payload)
@@ -76,7 +87,58 @@ class GitHub(Service):
         else:
             return None
 
-    def _call(self, request_payload):
+    def projects(self, username: str) -> List[ProjectData]:
+        cursor = None
+        datas = []
+        while True:
+            request_payload = {
+                'query': '''
+                    query { 
+                      user(login: "%(user_name)s") {
+                        repositories(after: %(cursor)s, first: %(page_size)s) {
+                          pageInfo {
+                            endCursor
+                          }
+                          nodes {
+                            name
+                            createdAt
+                            pushedAt
+                            languages(first: %(page_size)s) {
+                              nodes {
+                                name
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                ''' % {
+                    'user_name': username,
+                    'cursor': ('\"%s\"' % cursor) if cursor else 'null',
+                    'page_size': self._page_size
+                }
+            }
+            response_data = self._call(request_payload)
+            response_user = response_data['user']
+            repositories = response_user['repositories']['nodes']
+            for repository in repositories:
+                raw_creation_date = repository['createdAt']
+                raw_latest_push_date = repository['pushedAt']
+                latest_push_date = self._parse_datetime(raw_latest_push_date)
+                if latest_push_date + self._active_projects_period > datetime.utcnow():
+                    raw_latest_push_date = None
+                tags = list(set(language['name'] for language in repository['languages']['nodes']))
+                datas.append(ProjectData(name=repository['name'], start=raw_creation_date, end=raw_latest_push_date,
+                                         tags=tags))
+            cursor = response_user['repositories']['pageInfo']['endCursor']
+            if not cursor:
+                break
+        return datas
+
+    def _parse_datetime(self, datetime_string) -> datetime:
+        return datetime.strptime(datetime_string, self._date_format)
+
+    def _call(self, request_payload) -> dict:
         response_json = self._call_graphql(request_payload)
         if 'errors' in response_json:
             raise GitHubException('GraphQL call ended up in an error: %s'
@@ -92,7 +154,9 @@ class GitHub(Service):
 
     @property
     def token(self) -> str:
-        return self._token or self._generate_token()
+        if not self._token:
+            self._token = self._generate_token()
+        return self._token
 
     def _generate_token(self) -> str:
         jwt_token = self._generate_jwt()

--- a/backend/franky/service/service.py
+++ b/backend/franky/service/service.py
@@ -1,11 +1,31 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, List
 
 from model import UserData
+from model.project import ProjectData
 
 
 class Service(ABC):
+    """
+    Common abstract class for all Franky integrated service which can be used to aggregate different user profile data.
+    """
 
     @abstractmethod
     def user(self, username: str) -> Optional[UserData]:
+        """
+        Returns a user metadata.
+
+        :param username: User to get data for.
+        :return: User metadata.
+        """
+        pass
+
+    @abstractmethod
+    def projects(self, username: str) -> List[ProjectData]:
+        """
+        Returns a list of user projects.
+
+        :param username: User to list projects for.
+        :return: A list of user projects.
+        """
         pass

--- a/backend/tests/integration/github/test_github_integration.py
+++ b/backend/tests/integration/github/test_github_integration.py
@@ -8,7 +8,7 @@ def github():
 
 
 def test_github_returns_user_metadata(github):
-    user = github.user('tcibinan')
+    user = github.user('octocat')
     assert user.name
     assert user.login
     assert user.languages
@@ -17,3 +17,11 @@ def test_github_returns_user_metadata(github):
 def test_github_fails_if_user_does_not_exists(github):
     with pytest.raises(GitHubException):
         github.user('')
+
+
+def test_github_returns_user_projects(github):
+    projects = github.projects('octocat')
+    assert projects
+    for project in projects:
+        assert project.name
+        assert project.start


### PR DESCRIPTION
# Summary

Resolves #28.

Adds GitHub projects endpoint. See referenced issue for detailed info about the endpoint.

GET `/api/github/{GitHub login}/projects`.

```
[
    {
        "name": "Repository name",
        "start": "2018-09-11T06:17:10Z",
        "end": "2018-10-06T22:14:27Z",
        "tags": [ "Python", "Javascript" ]
    },
   ...
]
```