### PR TITLE
Add github user tag weights

### DIFF
--- a/backend/franky/model/user.py
+++ b/backend/franky/model/user.py
@@ -1,16 +1,16 @@
-from typing import Optional, List
+from typing import Optional, Dict
 
 
 class UserData:
 
-    def __init__(self, login: str, name: Optional[str], languages: List[str]):
+    def __init__(self, login: str, name: Optional[str], tags: Dict[str, str]):
         """
         User metadata.
 
         :param login: Unique user login. Such as john_johnson.
         :param name: Non unique user name. Such as John Johnson.
-        :param languages: A list of languages that user is associated with.
+        :param tags: User tag probabilities dictionary.
         """
         self.login = login
         self.name = name
-        self.languages = languages or []
+        self.tags = tags or {}

--- a/backend/tests/integration/github/test_github_integration.py
+++ b/backend/tests/integration/github/test_github_integration.py
@@ -11,7 +11,7 @@ def test_github_returns_user_metadata(github):
     user = github.user('octocat')
     assert user.name
     assert user.login
-    assert user.languages
+    assert user.tags
 
 
 def test_github_fails_if_user_does_not_exists(github):


### PR DESCRIPTION
Resolves issue #35 for GitHub service.

The pull request updates GitHub service endpoint adding user tag weights.

GET `/api/github/{GitHub login}`
```
{
    "login": "user_login",
    "name": "User Name",
    "tags": {
        "Python": 0.6,
        "Javascript": 0.4
    ]
}
```