### PR TITLE
Discard empty github user name

### DIFF
--- a/backend/franky/service/github/github.py
+++ b/backend/franky/service/github/github.py
@@ -73,7 +73,7 @@ class GitHub(Service):
             response_data = self._call(request_payload)
             response_user = response_data['user']
             login = response_user['login']
-            name = response_user['name']
+            name = response_user['name'] if response_user['name'] else None
             languages = list(set(language['name']
                                  for repository in response_user['repositories']['nodes']
                                  for language in repository['languages']['nodes']))


### PR DESCRIPTION
Resolves #36.

The original issue was caused by the way GitHub API handles empty names. Sometimes it returns empty string and the other time it returns null names. 

The original problem is completely GitHub's issue. Nevertheless, the pull request makes additional changes to ignore empty GitHub user names.